### PR TITLE
fix: use Firebase Admin SDK for contact message storage

### DIFF
--- a/src/lib/firebase-service.ts
+++ b/src/lib/firebase-service.ts
@@ -1,21 +1,21 @@
-import { db } from './firebase';
-import { collection, addDoc, updateDoc, doc, Timestamp } from 'firebase/firestore';
+import { adminDb } from './firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
 
 interface ContactMessage {
   name: string;
   email: string;
   phone: string;
   message: string;
-  sent_at: Timestamp | null;
-  created_at: Timestamp;
+  sent_at: FieldValue | null;
+  created_at: FieldValue;
 }
 
 export const saveContactMessage = async (data: Omit<ContactMessage, 'sent_at' | 'created_at'>) => {
   try {
-    const docRef = await addDoc(collection(db, 'contact_messages'), {
+    const docRef = await adminDb.collection('contact_messages').add({
       ...data,
       sent_at: null,
-      created_at: Timestamp.now()
+      created_at: FieldValue.serverTimestamp()
     });
     return docRef.id;
   } catch (error) {
@@ -26,9 +26,8 @@ export const saveContactMessage = async (data: Omit<ContactMessage, 'sent_at' | 
 
 export const updateMessageSentStatus = async (messageId: string) => {
   try {
-    const messageRef = doc(db, 'contact_messages', messageId);
-    await updateDoc(messageRef, {
-      sent_at: Timestamp.now()
+    await adminDb.collection('contact_messages').doc(messageId).update({
+      sent_at: FieldValue.serverTimestamp()
     });
   } catch (error) {
     console.error('Error updating message sent status:', error);


### PR DESCRIPTION
Switch from client SDK to Admin SDK in firebase-service.ts to fix PERMISSION_DENIED errors when saving contact messages from server actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Firestore write code paths; main risk is misconfigured Admin credentials/env vars causing runtime failures.
> 
> **Overview**
> Fixes server-side contact form persistence by switching Firestore writes in `firebase-service.ts` from the client SDK to the Firebase Admin SDK.
> 
> `saveContactMessage` and `updateMessageSentStatus` now use `adminDb` and `FieldValue.serverTimestamp()` for `created_at`/`sent_at`, and the message type is updated accordingly to avoid `PERMISSION_DENIED` issues from server actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b35eb2140722c641137ac176696dc3dea555e230. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->