### PR TITLE
Add CrossFit Level 1 soft skill with pending certificate

### DIFF
--- a/src/components/PDFResume.tsx
+++ b/src/components/PDFResume.tsx
@@ -459,7 +459,11 @@ export const PDFResume = ({
             {profileData.softSkills.map((softSkill, index) => (
               <Text key={index} style={styles.languageItem}>
                 {softSkill.name}: &nbsp;
-                <Link src={softSkill.url} style={styles.languageItem}>{softSkill.issuer}</Link>
+                {softSkill.url ? (
+                  <Link src={softSkill.url} style={styles.languageItem}>{softSkill.issuer}</Link>
+                ) : (
+                  softSkill.issuer
+                )}
               </Text>
             ))}
           </View>

--- a/src/components/sections/education.tsx
+++ b/src/components/sections/education.tsx
@@ -91,6 +91,7 @@ export function Education({ educationEntries, certifications, languages, current
                   >
                     {softSkill.name}
                   </Badge>
+                  {softSkill.url ? (
                     <a 
                       href={softSkill.url} 
                       target="_blank" 
@@ -99,6 +100,9 @@ export function Education({ educationEntries, certifications, languages, current
                     >
                       {softSkill.issuer}
                     </a>
+                  ) : (
+                    <span className="text-gray-600 text-sm ml-1">{softSkill.issuer}</span>
+                  )}
                 </div>
               );
             })}

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -153,6 +153,15 @@
       },
       "url": "/certificates/baptiste-yoga-teacher.pdf",
       "issuer": "Baptiste Power Yoga San Francisco"
+    },
+    {
+      "name": {
+        "en": "CrossFit Level 1 Trainer",
+        "es": "Entrenador CrossFit Nivel 1",
+        "fr": "Coach CrossFit Niveau 1",
+        "de": "CrossFit Level 1 Trainer"
+      },
+      "issuer": "CrossFit | April 2026"
     }
   ]
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -60,7 +60,7 @@ export const getProfileData = (lang: Language): ProfileData => {
       ...(l.certifications && { certifications: l.certifications }),
     })),
     certifications,
-    softSkills: raw.softSkills.map((s: { name: TranslatableString; url: string; issuer: string }) => ({
+    softSkills: raw.softSkills.map((s: { name: TranslatableString; url?: string; issuer: string }) => ({
       name: resolve(s.name, lang.code),
       url: s.url,
       issuer: s.issuer,

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -12,7 +12,7 @@ export interface ExperienceEntry {
 
 export interface SoftSkillEntry {
   name: string;
-  url: string;
+  url?: string;
   issuer: string;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new soft-skill entry for **CrossFit Level 1 Trainer** in `src/data/profile.json`
- include the achievement date as **April 2026**
- keep certificate document pending for now (no URL yet), while preserving the same soft-skills structure used for yoga
- make soft-skill certificate URLs optional across data/types/rendering so entries can exist before documents are uploaded

## Technical changes
- update `SoftSkillEntry` to allow optional `url`
- update profile data mapping to handle optional soft-skill URL
- update web education section to render issuer text when URL is missing
- update PDF resume rendering to render issuer text when URL is missing

## Validation
- `npm run lint` ✅
- `npm test` ✅ (4/4 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-170401bf-fb57-49fc-8d04-e7bd01d0b5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-170401bf-fb57-49fc-8d04-e7bd01d0b5cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

